### PR TITLE
fix: latest_version is empty after 500 status from Steam API and an update would be triggered

### DIFF
--- a/scripts/default/plainsofpain-updater
+++ b/scripts/default/plainsofpain-updater
@@ -31,7 +31,7 @@ checkForUpdates() {
 
   latest_version=$(curl -sX GET "https://api.steamcmd.net/v1/info/$steam_app_id" | jq -r ".data.\"$steam_app_id\".depots.branches.$GAME_BRANCH.buildid")
 
-  if [ "$latest_version" == "null" ] || [ "$latest_version" == "-1" ]; then
+  if [ "$latest_version" == "null" ] || [ "$latest_version" == "" ] || [ "$latest_version" == "-1" ]; then
     if [ "$current_version" == "0" ]; then
       warn "Unable to determine latest version of Plains of Pain server! No version currently installed, update server anyways"
       return 0


### PR DESCRIPTION
Hopefully this will fix the unnecessary updates/restarts